### PR TITLE
Enforce required TLS client certificates

### DIFF
--- a/src/main/java/io/mapsmessaging/security/ssl/SslHelper.java
+++ b/src/main/java/io/mapsmessaging/security/ssl/SslHelper.java
@@ -153,10 +153,14 @@ public class SslHelper {
     return sslContext;
   }
 
-  public static SSLEngine createSSLEngine(SSLContext sslContext, ConfigurationProperties tls){
+  public static SSLEngine createSSLEngine(SSLContext sslContext, ConfigurationProperties tls) {
     SSLEngine sslEngine = sslContext.createSSLEngine();
-    sslEngine.setNeedClientAuth(tls.getBooleanProperty("clientCertificateRequired", false));
-    sslEngine.setWantClientAuth(tls.getBooleanProperty("clientCertificateWanted", false));
+    boolean clientCertificateRequired = tls.getBooleanProperty("clientCertificateRequired", false);
+    if (clientCertificateRequired) {
+      sslEngine.setNeedClientAuth(true);
+    } else {
+      sslEngine.setWantClientAuth(tls.getBooleanProperty("clientCertificateWanted", false));
+    }
     return sslEngine;
   }
 

--- a/src/test/java/io/mapsmessaging/security/ssl/SslHelperTest.java
+++ b/src/test/java/io/mapsmessaging/security/ssl/SslHelperTest.java
@@ -54,4 +54,25 @@ class SslHelperTest extends BaseCertificateTest {
     SSLEngine sslEngine = SslHelper.createSSLEngine(sslContext, new ConfigurationProperties() );
     Assertions.assertNotNull(sslEngine);
   }
+
+  @Test
+  void clientCertificateAuthenticationModesAreMutuallyExclusive() throws Exception {
+    SSLContext sslContext = SSLContext.getDefault();
+
+    assertClientAuthenticationMode(sslContext, false, false, false, false);
+    assertClientAuthenticationMode(sslContext, false, true, false, true);
+    assertClientAuthenticationMode(sslContext, true, false, true, false);
+    assertClientAuthenticationMode(sslContext, true, true, true, false);
+  }
+
+  private void assertClientAuthenticationMode(SSLContext sslContext, boolean required, boolean wanted, boolean expectedRequired, boolean expectedWanted) {
+    ConfigurationProperties properties = new ConfigurationProperties();
+    properties.put("clientCertificateRequired", required);
+    properties.put("clientCertificateWanted", wanted);
+
+    SSLEngine sslEngine = SslHelper.createSSLEngine(sslContext, properties);
+
+    Assertions.assertEquals(expectedRequired, sslEngine.getNeedClientAuth());
+    Assertions.assertEquals(expectedWanted, sslEngine.getWantClientAuth());
+  }
 }


### PR DESCRIPTION
## What changed

- configure exactly one SSLEngine client-authentication mode
- give required client authentication precedence over optional authentication
- add regression coverage for all required/wanted combinations

## Root cause

SSLEngine client-authentication setters override each other. Calling setWantClientAuth after setNeedClientAuth cleared the required setting, including when wanted was false.

## Impact

TLS servers configured with clientCertificateRequired=true now retain mandatory client-certificate authentication and reject peers that do not provide an acceptable certificate.

## Validation

Added unit assertions for disabled, wanted, required, and conflicting required/wanted configurations.